### PR TITLE
유효성검사 코드 수정 등등..

### DIFF
--- a/app/src/main/java/com/example/anafor/MainActivity.java
+++ b/app/src/main/java/com/example/anafor/MainActivity.java
@@ -13,6 +13,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -53,7 +54,7 @@ public class MainActivity extends AppCompatActivity {
     DrawerLayout drawer;
     NavigationView nav_view;
     ViewFlipper pic_Slid; // 사진 슬라이드
-    TextView tv_login, tv_edit; //신보배 0522 코드추가
+    TextView tv_login, tv_edit;
 
     /* 위치 권한 확인을 위한 코드 */
     private static final int GPS_ENABLE_REQUEST_CODE = 2001;
@@ -94,15 +95,6 @@ public class MainActivity extends AppCompatActivity {
         //headerView tv 아이디찾기
         tv_login = headerView.findViewById(R.id.tv_main_header_login);
         tv_edit = headerView.findViewById(R.id.tv_main_header_edit);
-
-        //로그인
-        tv_login.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(MainActivity.this, LoginActivity.class);
-                startActivity(intent);
-            }
-        });
 
         changeFragment(new Hp_MainFragment());
 
@@ -319,25 +311,26 @@ public class MainActivity extends AppCompatActivity {
                 || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
     }
 
-    //신보배 0517 코드 추가
+    //로그인   했을때 : 사용자이름 띄우고 로그인버튼을 수정버튼으로 텍스트변경, 버튼클릭시 회원정보 정보수정화면으로 intent
+    //로그아웃 했을때 : 로그인버튼 클릭시 로그인화면으로 intent
     @Override
     protected void onResume() {
         super.onResume();
-        if(CommonVal.loginInfo != null){
-            tv_login.setText(CommonVal.loginInfo.getUser_name()+"님 반갑습니다");
-            tv_login.setOnClickListener(new View.OnClickListener() {
+        if(CommonVal.loginInfo != null) {
+            tv_login.setText(CommonVal.loginInfo.getUser_name() + "님 반갑습니다");
+            tv_edit.setText("수정");
+            tv_edit.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     Intent intent = new Intent(MainActivity.this, UserInfoActivity.class);
                     startActivity(intent);
                 }
             });
-            
-            //신보배 0522코드추가
+        }else{
             tv_edit.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Intent intent = new Intent(MainActivity.this, UserInfoActivity.class);
+                    Intent intent = new Intent(MainActivity.this, LoginActivity.class);
                     startActivity(intent);
                 }
             });

--- a/app/src/main/java/com/example/anafor/User/PwFindActivity.java
+++ b/app/src/main/java/com/example/anafor/User/PwFindActivity.java
@@ -4,6 +4,8 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -24,7 +26,6 @@ import java.io.InputStreamReader;
 public class PwFindActivity extends AppCompatActivity {
     private static final String TAG = "비밀번호찾기";
     Button btn_find;
-
     TextInputLayout til_id;
     TextInputEditText tiedt_id;
 
@@ -45,6 +46,22 @@ public class PwFindActivity extends AppCompatActivity {
         btn_find = findViewById(R.id.btn_pwFind_btn);
         til_id = findViewById(R.id.til_pwFind_id);
         tiedt_id = findViewById(R.id.tiedt_pwFind_id);
+        tiedt_id.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                til_id.setError(null);
+            }
+        });
 
         btn_find.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/layout/activity_join.xml
+++ b/app/src/main/res/layout/activity_join.xml
@@ -69,7 +69,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="15dp"
-                android:text="*필수입력"
+                android:text="*필수입력사항"
                 android:textSize="10dp"
                 android:layout_gravity="right"/>
             <!--이메일-->
@@ -279,7 +279,8 @@
                     android:layout_height="wrap_content"
                     android:text="남"
                     android:textColor="#595959"
-                    android:layout_marginRight="50dp" />
+                    android:layout_marginRight="50dp"
+                    android:checked="true"/>
                 <RadioButton
                     android:id="@+id/rdoBtn_join_female"
                     android:layout_width="50dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -104,19 +104,8 @@
         android:gravity="center"
         android:textSize="15dp"
         android:visibility="visible"
-        android:text="한울직업전문학교"/>
+        android:text="AnaFor"/>
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="20dp"
-            android:textStyle="bold"
-            android:layout_marginTop="740dp"
-            android:layout_marginBottom="10dp"
-            android:textColor="@color/white"
-            android:gravity="center"
-            android:textSize="15dp"
-            android:text="로그아웃"
-            android:visibility="invisible"/>
     </com.google.android.material.navigation.NavigationView>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/header_layout.xml
+++ b/app/src/main/res/layout/header_layout.xml
@@ -27,7 +27,7 @@
         android:layout_gravity="center"
         android:layout_marginTop="-10dp"
         android:layout_marginLeft="10dp"
-        android:text="아픈 나를 위해 아나포" />
+        android:text="안아플 나를 위해 아나포" />
 
     <View
         android:layout_width="wrap_content"
@@ -49,10 +49,10 @@
             android:layout_marginTop="30dp"
             android:layout_marginLeft="12dp"
             android:layout_marginBottom="3dp"
-            android:textSize="17dp"
+            android:textSize="20dp"
             android:textStyle="bold"
             android:textColor="#fff"
-            android:text="로그인을 하시려면 여기를 클릭해주세요."/>
+            android:text="로그인 해주세요"/>
         <TextView
             android:id="@+id/tv_main_header_edit"
             android:layout_width="wrap_content"
@@ -63,7 +63,7 @@
             android:paddingRight="10dp"
             android:paddingTop="2dp"
             android:paddingBottom="2dp"
-            android:text="수정"
+            android:text="로그인"
             android:textStyle="bold"
             android:background="@drawable/round_button"/>
     </LinearLayout>


### PR DESCRIPTION
MainActivity : 헤더의 로그인 버튼이 텍스트 옆으로 밀려서 가려져 있었음
해당 부분 알고 시정함
로그인했을때 로그인버튼이 수정버튼으로 텍스트 변경되고 intent도
userInfoActivity로 변경됨

JoinAcitivity : 유효성 검사 에러 뜨는데도 회원 가입에 성공하는 문제점이 있었음
아이디 중복 확인을 눌러서 사용 가능한 메일일 때만 인증 코드 버튼이 활성화 되게 하였음
인증코드 틀리게 입력할시를 포함해서
모든 유효성검사 에러 상태일 때는 토스트 띄우고 회원가입으로 넘어가지 않음
회원가입 성공시 환영토스트창 띄우고 로그인액티비티로 이동

PwFindActivity : 가입한 이메일 입력하고 버튼 클릭했을때
등록되지 않은 이메일일 경우 에러메세지가 뜨는데
이메일을 다시 입력하기위해서 수정해도 에러가 남아있는 문제점이있어서 에러없애는 코드 추가함

activity_join : 성별체크 남자를 디폴트로 해둠

activity_main : 헤더 하단에 한울직업전문학교를 아나포로 텍스트 변경
로그아웃 텍스트뷰는 천일이가 임시로 만든건데 사용하지 않아서 삭제함